### PR TITLE
Regenerate endpoint mappings (LUKSO-motivated)

### DIFF
--- a/lynx.json
+++ b/lynx.json
@@ -20,7 +20,6 @@
     ],
     "42": [
         "https://42.rpc.thirdweb.com",
-        "https://rpc.lukso.sigmacore.io",
         "https://rpc.mainnet.lukso.network"
     ],
     "56": [
@@ -61,14 +60,12 @@
     "137": [
         "https://polygon-bor-rpc.publicnode.com",
         "https://polygon-public.nodies.app",
-        "https://polygon-rpc.com/",
         "https://polygon.drpc.org",
         "https://polygon.gateway.tenderly.co",
         "https://rpc-mainnet.matic.quiknode.pro"
     ],
     "300": [
-        "https://sepolia.era.zksync.dev",
-        "https://zksync-sepolia.drpc.org"
+        "https://sepolia.era.zksync.dev"
     ],
     "314": [
         "https://api.node.glif.io/",
@@ -82,7 +79,8 @@
         "https://eth-rpc.testnet.near.org"
     ],
     "7700": [
-        "https://canto-rpc.ansybl.io"
+        "https://canto-rpc.ansybl.io",
+        "https://canto.gravitychain.io/"
     ],
     "8453": [
         "https://base-public.nodies.app",
@@ -127,13 +125,7 @@
         "https://base-sepolia.gateway.tenderly.co",
         "https://sepolia.base.org"
     ],
-    "314159": [
-        "https://api.calibration.node.glif.io/rpc/v1",
-        "https://filecoin-calibration.drpc.org",
-        "https://rpc.ankr.com/filecoin_testnet"
-    ],
     "421614": [
-        "https://api.zan.top/arb-sepolia",
         "https://arbitrum-sepolia-rpc.publicnode.com",
         "https://arbitrum-sepolia.drpc.org",
         "https://arbitrum-sepolia.gateway.tenderly.co",
@@ -153,12 +145,12 @@
     ],
     "11155111": [
         "https://ethereum-sepolia-rpc.publicnode.com",
+        "https://rpc.sepolia.ethpandaops.io",
         "https://sepolia.drpc.org",
         "https://sepolia.gateway.tenderly.co"
     ],
     "11155420": [
         "https://api.zan.top/opt-sepolia",
-        "https://endpoints.omniatech.io/v1/op/sepolia/public",
         "https://optimism-sepolia-public.nodies.app",
         "https://optimism-sepolia.drpc.org",
         "https://optimism-sepolia.gateway.tenderly.co",

--- a/mainnet.json
+++ b/mainnet.json
@@ -20,7 +20,6 @@
     ],
     "42": [
         "https://42.rpc.thirdweb.com",
-        "https://rpc.lukso.sigmacore.io",
         "https://rpc.mainnet.lukso.network"
     ],
     "56": [
@@ -53,7 +52,6 @@
     "100": [
         "https://gnosis-public.nodies.app",
         "https://gnosis-rpc.publicnode.com",
-        "https://gnosis.drpc.org",
         "https://gnosis.oat.farm",
         "https://rpc.gnosis.gateway.fm",
         "https://rpc.gnosischain.com"
@@ -61,7 +59,6 @@
     "137": [
         "https://polygon-bor-rpc.publicnode.com",
         "https://polygon-public.nodies.app",
-        "https://polygon-rpc.com/",
         "https://polygon.drpc.org",
         "https://polygon.gateway.tenderly.co",
         "https://rpc-mainnet.matic.quiknode.pro"
@@ -82,7 +79,8 @@
         "https://eth-rpc.testnet.near.org"
     ],
     "7700": [
-        "https://canto-rpc.ansybl.io"
+        "https://canto-rpc.ansybl.io",
+        "https://canto.gravitychain.io/"
     ],
     "8453": [
         "https://base-public.nodies.app",
@@ -127,11 +125,6 @@
         "https://base-sepolia.gateway.tenderly.co",
         "https://sepolia.base.org"
     ],
-    "314159": [
-        "https://api.calibration.node.glif.io/rpc/v1",
-        "https://filecoin-calibration.drpc.org",
-        "https://rpc.ankr.com/filecoin_testnet"
-    ],
     "421614": [
         "https://api.zan.top/arb-sepolia",
         "https://arbitrum-sepolia-rpc.publicnode.com",
@@ -153,14 +146,13 @@
     ],
     "11155111": [
         "https://ethereum-sepolia-rpc.publicnode.com",
+        "https://rpc.sepolia.ethpandaops.io",
         "https://sepolia.drpc.org",
         "https://sepolia.gateway.tenderly.co"
     ],
     "11155420": [
         "https://api.zan.top/opt-sepolia",
-        "https://endpoints.omniatech.io/v1/op/sepolia/public",
         "https://optimism-sepolia-public.nodies.app",
-        "https://optimism-sepolia.drpc.org",
         "https://optimism-sepolia.gateway.tenderly.co",
         "https://sepolia.optimism.io"
     ],

--- a/scripts/generate_endpoint_mapping.py
+++ b/scripts/generate_endpoint_mapping.py
@@ -32,7 +32,8 @@ ALL_CHAINS = {
     43114,  # Avalanche C-Chain
     80002,  # Amoy
     84532,  # Base Sepolia Testnet
-    314159,  # Filecoin - Calibration testnet
+    # TODO: No viable endpoints available for Filecoin - Calibration testnet during last execution of script
+    # 314159,  # Filecoin - Calibration testnet
     421614,  # Arbitrum Sepolia
     534351,  # Scroll Sepolia Testnet
     534352,  # Scroll

--- a/tapir.json
+++ b/tapir.json
@@ -20,7 +20,6 @@
     ],
     "42": [
         "https://42.rpc.thirdweb.com",
-        "https://rpc.lukso.sigmacore.io",
         "https://rpc.mainnet.lukso.network"
     ],
     "56": [
@@ -61,7 +60,6 @@
     "137": [
         "https://polygon-bor-rpc.publicnode.com",
         "https://polygon-public.nodies.app",
-        "https://polygon-rpc.com/",
         "https://polygon.drpc.org",
         "https://polygon.gateway.tenderly.co",
         "https://rpc-mainnet.matic.quiknode.pro"
@@ -82,7 +80,8 @@
         "https://eth-rpc.testnet.near.org"
     ],
     "7700": [
-        "https://canto-rpc.ansybl.io"
+        "https://canto-rpc.ansybl.io",
+        "https://canto.gravitychain.io/"
     ],
     "8453": [
         "https://base-public.nodies.app",
@@ -127,11 +126,6 @@
         "https://base-sepolia.gateway.tenderly.co",
         "https://sepolia.base.org"
     ],
-    "314159": [
-        "https://api.calibration.node.glif.io/rpc/v1",
-        "https://filecoin-calibration.drpc.org",
-        "https://rpc.ankr.com/filecoin_testnet"
-    ],
     "421614": [
         "https://api.zan.top/arb-sepolia",
         "https://arbitrum-sepolia-rpc.publicnode.com",
@@ -153,12 +147,12 @@
     ],
     "11155111": [
         "https://ethereum-sepolia-rpc.publicnode.com",
+        "https://rpc.sepolia.ethpandaops.io",
         "https://sepolia.drpc.org",
         "https://sepolia.gateway.tenderly.co"
     ],
     "11155420": [
         "https://api.zan.top/opt-sepolia",
-        "https://endpoints.omniatech.io/v1/op/sepolia/public",
         "https://optimism-sepolia-public.nodies.app",
         "https://optimism-sepolia.drpc.org",
         "https://optimism-sepolia.gateway.tenderly.co",


### PR DESCRIPTION
Prompted by the fact that one of the existing LUKSO public RPC endpoints (chain ID 42) was observed as being faulty and was indeed remove on the latest run of the script.