### PR TITLE
Use Supplemental Endpoints / Remove `--domain` parameter

### DIFF
--- a/lynx.json
+++ b/lynx.json
@@ -1,29 +1,62 @@
 {
     "1": [
+        "https://0xrpc.io/eth",
+        "https://1rpc.io/eth",
+        "https://api.zan.top/eth-mainnet",
+        "https://core.gashawk.io/rpc",
+        "https://eth-mainnet.public.blastapi.io",
+        "https://eth.api.onfinality.io/public",
+        "https://eth.blockrazor.xyz",
         "https://eth.drpc.org",
+        "https://eth.llamarpc.com",
+        "https://eth.meowrpc.com",
+        "https://eth.merkle.io",
+        "https://eth.rpc.blxrbdn.com",
+        "https://eth1.lava.build",
         "https://ethereum-public.nodies.app",
         "https://ethereum-rpc.publicnode.com",
+        "https://ethereum.public.blockpi.network/v1/rpc/public",
+        "https://ethereum.rpc.subquery.network/public",
+        "https://gateway.tenderly.co/public/mainnet",
         "https://mainnet.gateway.tenderly.co",
+        "https://rpc.eth.gateway.fm",
         "https://rpc.flashbots.net",
         "https://rpc.flashbots.net/fast",
         "https://rpc.mevblocker.io",
         "https://rpc.mevblocker.io/fast",
         "https://rpc.mevblocker.io/fullprivacy",
-        "https://rpc.mevblocker.io/noreverts"
+        "https://rpc.mevblocker.io/noreverts",
+        "https://singapore.rpc.blxrbdn.com",
+        "https://uk.rpc.blxrbdn.com",
+        "https://virginia.rpc.blxrbdn.com"
     ],
     "10": [
+        "https://1rpc.io/op",
+        "https://api.zan.top/opt-mainnet",
+        "https://gateway.tenderly.co/public/optimism",
         "https://mainnet.optimism.io",
         "https://optimism-public.nodies.app",
         "https://optimism-rpc.publicnode.com",
+        "https://optimism.api.onfinality.io/public",
         "https://optimism.drpc.org",
-        "https://optimism.gateway.tenderly.co"
+        "https://optimism.gateway.tenderly.co",
+        "https://optimism.public.blockpi.network/v1/rpc/public",
+        "https://optimism.rpc.subquery.network/public"
     ],
     "42": [
         "https://42.rpc.thirdweb.com",
         "https://rpc.mainnet.lukso.network"
     ],
     "56": [
+        "https://0.48.club",
+        "https://1rpc.io/bnb",
+        "https://56.rpc.thirdweb.com",
+        "https://api.zan.top/bsc-mainnet",
         "https://binance-smart-chain-public.nodies.app",
+        "https://binance.nodereal.io",
+        "https://bnb.api.onfinality.io/public",
+        "https://bnb.rpc.subquery.network/public",
+        "https://bsc-dataseed.bnbchain.org",
         "https://bsc-dataseed1.bnbchain.org",
         "https://bsc-dataseed1.defibit.io",
         "https://bsc-dataseed1.ninicoin.io",
@@ -36,10 +69,17 @@
         "https://bsc-dataseed4.bnbchain.org",
         "https://bsc-dataseed4.defibit.io",
         "https://bsc-dataseed4.ninicoin.io",
+        "https://bsc-mainnet.public.blastapi.io",
         "https://bsc-rpc.publicnode.com",
-        "https://bsc.drpc.org"
+        "https://bsc.blockrazor.xyz",
+        "https://bsc.drpc.org",
+        "https://bsc.meowrpc.com",
+        "https://bsc.rpc.blxrbdn.com",
+        "https://rpc-bsc.48.club"
     ],
     "97": [
+        "https://api.zan.top/bsc-testnet",
+        "https://bnb-testnet.api.onfinality.io/public",
         "https://bsc-testnet-rpc.publicnode.com",
         "https://bsc-testnet.drpc.org",
         "https://data-seed-prebsc-1-s1.bnbchain.org:8545",
@@ -50,26 +90,40 @@
         "https://data-seed-prebsc-2-s3.bnbchain.org:8545"
     ],
     "100": [
+        "https://1rpc.io/gnosis",
         "https://gnosis-public.nodies.app",
         "https://gnosis-rpc.publicnode.com",
         "https://gnosis.drpc.org",
         "https://gnosis.oat.farm",
+        "https://rpc.ap-southeast-1.gateway.fm/v4/gnosis/non-archival/mainnet",
         "https://rpc.gnosis.gateway.fm",
         "https://rpc.gnosischain.com"
     ],
     "137": [
+        "https://1rpc.io/matic",
+        "https://api.zan.top/polygon-mainnet",
+        "https://gateway.tenderly.co/public/polygon",
         "https://polygon-bor-rpc.publicnode.com",
+        "https://polygon-mainnet.gateway.tatum.io",
         "https://polygon-public.nodies.app",
+        "https://polygon.api.onfinality.io/public",
         "https://polygon.drpc.org",
         "https://polygon.gateway.tenderly.co",
+        "https://polygon.lava.build",
+        "https://polygon.rpc.subquery.network/public",
         "https://rpc-mainnet.matic.quiknode.pro"
     ],
     "300": [
-        "https://sepolia.era.zksync.dev"
+        "https://rpc.ankr.com/zksync_era_sepolia",
+        "https://sepolia.era.zksync.dev",
+        "https://zksync-sepolia.drpc.org"
     ],
     "314": [
-        "https://api.node.glif.io/",
+        "https://api.chain.love/rpc/v1",
+        "https://api.node.glif.io",
+        "https://api.node.glif.io/rpc/v1",
         "https://filecoin.drpc.org",
+        "https://filecoin.lava.build",
         "https://rpc.ankr.com/filecoin"
     ],
     "397": [
@@ -80,15 +134,25 @@
     ],
     "7700": [
         "https://canto-rpc.ansybl.io",
-        "https://canto.gravitychain.io/"
+        "https://canto.gravitychain.io"
     ],
     "8453": [
+        "https://1rpc.io/base",
+        "https://api.zan.top/base-mainnet",
+        "https://base-mainnet.gateway.tatum.io",
+        "https://base-mainnet.public.blastapi.io",
         "https://base-public.nodies.app",
         "https://base-rpc.publicnode.com",
         "https://base.drpc.org",
         "https://base.gateway.tenderly.co",
-        "https://developer-access-mainnet.base.org/",
-        "https://mainnet.base.org/"
+        "https://base.lava.build",
+        "https://base.meowrpc.com",
+        "https://base.public.blockpi.network/v1/rpc/public",
+        "https://base.rpc.subquery.network/public",
+        "https://developer-access-mainnet.base.org",
+        "https://gateway.tenderly.co/public/base",
+        "https://mainnet-preconf.base.org",
+        "https://mainnet.base.org"
     ],
     "10200": [
         "https://gnosis-chiado-rpc.publicnode.com",
@@ -97,35 +161,57 @@
         "https://rpc.chiadochain.net"
     ],
     "42161": [
+        "https://1rpc.io/arb",
+        "https://api.zan.top/arb-one",
         "https://arb1.arbitrum.io/rpc",
+        "https://arb1.lava.build",
         "https://arbitrum-one-public.nodies.app",
         "https://arbitrum-one-rpc.publicnode.com",
-        "https://arbitrum.drpc.org"
+        "https://arbitrum-one.public.blastapi.io",
+        "https://arbitrum.drpc.org",
+        "https://arbitrum.gateway.tenderly.co",
+        "https://arbitrum.meowrpc.com",
+        "https://arbitrum.public.blockpi.network/v1/rpc/public",
+        "https://arbitrum.rpc.subquery.network/public"
     ],
     "42220": [
         "https://1rpc.io/celo",
+        "https://celo-json-rpc.stakely.io",
         "https://celo.drpc.org",
-        "https://forno.celo.org"
+        "https://forno.celo.org",
+        "https://rpc.ankr.com/celo"
     ],
     "43114": [
+        "https://1rpc.io/avax/c",
         "https://api.avax.network/ext/bc/C/rpc",
+        "https://api.zan.top/avax-mainnet/ext/bc/C/rpc",
         "https://avalanche-c-chain-rpc.publicnode.com",
-        "https://avalanche.drpc.org"
+        "https://avalanche-mainnet.gateway.tenderly.co",
+        "https://avalanche-public.nodies.app/ext/bc/C/rpc",
+        "https://avalanche.api.onfinality.io/public/ext/bc/C/rpc",
+        "https://avalanche.drpc.org",
+        "https://spectrum-01.simplystaking.xyz/avalanche-mn-rpc/ext/bc/C/rpc"
     ],
     "80002": [
+        "https://api.zan.top/polygon-amoy",
         "https://polygon-amoy-bor-rpc.publicnode.com",
         "https://polygon-amoy-public.nodies.app",
+        "https://polygon-amoy.api.onfinality.io/public",
         "https://polygon-amoy.drpc.org",
+        "https://polygon-amoy.gateway.tenderly.co",
         "https://rpc-amoy.polygon.technology"
     ],
     "84532": [
         "https://base-sepolia-public.nodies.app",
         "https://base-sepolia-rpc.publicnode.com",
+        "https://base-sepolia.api.onfinality.io/public",
         "https://base-sepolia.drpc.org",
         "https://base-sepolia.gateway.tenderly.co",
+        "https://sepolia-preconf.base.org",
         "https://sepolia.base.org"
     ],
     "421614": [
+        "https://api.zan.top/arb-sepolia",
         "https://arbitrum-sepolia-rpc.publicnode.com",
         "https://arbitrum-sepolia.drpc.org",
         "https://arbitrum-sepolia.gateway.tenderly.co",
@@ -138,13 +224,22 @@
         "https://sepolia-rpc.scroll.io"
     ],
     "534352": [
+        "https://1rpc.io/scroll",
         "https://rpc.scroll.io",
         "https://scroll-public.nodies.app",
         "https://scroll-rpc.publicnode.com",
+        "https://scroll.api.onfinality.io/public",
         "https://scroll.drpc.org"
     ],
     "11155111": [
+        "https://0xrpc.io/sep",
+        "https://1rpc.io/sepolia",
+        "https://api.zan.top/eth-sepolia",
+        "https://eth-sepolia.api.onfinality.io/public",
+        "https://ethereum-sepolia-public.nodies.app",
         "https://ethereum-sepolia-rpc.publicnode.com",
+        "https://ethereum-sepolia.rpc.subquery.network/public",
+        "https://gateway.tenderly.co/public/sepolia",
         "https://rpc.sepolia.ethpandaops.io",
         "https://sepolia.drpc.org",
         "https://sepolia.gateway.tenderly.co"
@@ -152,6 +247,7 @@
     "11155420": [
         "https://api.zan.top/opt-sepolia",
         "https://optimism-sepolia-public.nodies.app",
+        "https://optimism-sepolia.api.onfinality.io/public",
         "https://optimism-sepolia.drpc.org",
         "https://optimism-sepolia.gateway.tenderly.co",
         "https://sepolia.optimism.io"

--- a/mainnet.json
+++ b/mainnet.json
@@ -1,29 +1,62 @@
 {
     "1": [
+        "https://0xrpc.io/eth",
+        "https://1rpc.io/eth",
+        "https://api.zan.top/eth-mainnet",
+        "https://core.gashawk.io/rpc",
+        "https://eth-mainnet.public.blastapi.io",
+        "https://eth.api.onfinality.io/public",
+        "https://eth.blockrazor.xyz",
         "https://eth.drpc.org",
+        "https://eth.llamarpc.com",
+        "https://eth.meowrpc.com",
+        "https://eth.merkle.io",
+        "https://eth.rpc.blxrbdn.com",
+        "https://eth1.lava.build",
         "https://ethereum-public.nodies.app",
         "https://ethereum-rpc.publicnode.com",
+        "https://ethereum.public.blockpi.network/v1/rpc/public",
+        "https://ethereum.rpc.subquery.network/public",
+        "https://gateway.tenderly.co/public/mainnet",
         "https://mainnet.gateway.tenderly.co",
+        "https://rpc.eth.gateway.fm",
         "https://rpc.flashbots.net",
         "https://rpc.flashbots.net/fast",
         "https://rpc.mevblocker.io",
         "https://rpc.mevblocker.io/fast",
         "https://rpc.mevblocker.io/fullprivacy",
-        "https://rpc.mevblocker.io/noreverts"
+        "https://rpc.mevblocker.io/noreverts",
+        "https://singapore.rpc.blxrbdn.com",
+        "https://uk.rpc.blxrbdn.com",
+        "https://virginia.rpc.blxrbdn.com"
     ],
     "10": [
+        "https://1rpc.io/op",
+        "https://api.zan.top/opt-mainnet",
+        "https://gateway.tenderly.co/public/optimism",
         "https://mainnet.optimism.io",
         "https://optimism-public.nodies.app",
         "https://optimism-rpc.publicnode.com",
+        "https://optimism.api.onfinality.io/public",
         "https://optimism.drpc.org",
-        "https://optimism.gateway.tenderly.co"
+        "https://optimism.gateway.tenderly.co",
+        "https://optimism.public.blockpi.network/v1/rpc/public",
+        "https://optimism.rpc.subquery.network/public"
     ],
     "42": [
         "https://42.rpc.thirdweb.com",
         "https://rpc.mainnet.lukso.network"
     ],
     "56": [
+        "https://0.48.club",
+        "https://1rpc.io/bnb",
+        "https://56.rpc.thirdweb.com",
+        "https://api.zan.top/bsc-mainnet",
         "https://binance-smart-chain-public.nodies.app",
+        "https://binance.nodereal.io",
+        "https://bnb.api.onfinality.io/public",
+        "https://bnb.rpc.subquery.network/public",
+        "https://bsc-dataseed.bnbchain.org",
         "https://bsc-dataseed1.bnbchain.org",
         "https://bsc-dataseed1.defibit.io",
         "https://bsc-dataseed1.ninicoin.io",
@@ -36,10 +69,17 @@
         "https://bsc-dataseed4.bnbchain.org",
         "https://bsc-dataseed4.defibit.io",
         "https://bsc-dataseed4.ninicoin.io",
+        "https://bsc-mainnet.public.blastapi.io",
         "https://bsc-rpc.publicnode.com",
-        "https://bsc.drpc.org"
+        "https://bsc.blockrazor.xyz",
+        "https://bsc.drpc.org",
+        "https://bsc.meowrpc.com",
+        "https://bsc.rpc.blxrbdn.com",
+        "https://rpc-bsc.48.club"
     ],
     "97": [
+        "https://api.zan.top/bsc-testnet",
+        "https://bnb-testnet.api.onfinality.io/public",
         "https://bsc-testnet-rpc.publicnode.com",
         "https://bsc-testnet.drpc.org",
         "https://data-seed-prebsc-1-s1.bnbchain.org:8545",
@@ -50,26 +90,40 @@
         "https://data-seed-prebsc-2-s3.bnbchain.org:8545"
     ],
     "100": [
+        "https://1rpc.io/gnosis",
         "https://gnosis-public.nodies.app",
         "https://gnosis-rpc.publicnode.com",
+        "https://gnosis.drpc.org",
         "https://gnosis.oat.farm",
+        "https://rpc.ap-southeast-1.gateway.fm/v4/gnosis/non-archival/mainnet",
         "https://rpc.gnosis.gateway.fm",
         "https://rpc.gnosischain.com"
     ],
     "137": [
+        "https://1rpc.io/matic",
+        "https://api.zan.top/polygon-mainnet",
+        "https://gateway.tenderly.co/public/polygon",
         "https://polygon-bor-rpc.publicnode.com",
+        "https://polygon-mainnet.gateway.tatum.io",
         "https://polygon-public.nodies.app",
+        "https://polygon.api.onfinality.io/public",
         "https://polygon.drpc.org",
         "https://polygon.gateway.tenderly.co",
+        "https://polygon.lava.build",
+        "https://polygon.rpc.subquery.network/public",
         "https://rpc-mainnet.matic.quiknode.pro"
     ],
     "300": [
+        "https://rpc.ankr.com/zksync_era_sepolia",
         "https://sepolia.era.zksync.dev",
         "https://zksync-sepolia.drpc.org"
     ],
     "314": [
-        "https://api.node.glif.io/",
+        "https://api.chain.love/rpc/v1",
+        "https://api.node.glif.io",
+        "https://api.node.glif.io/rpc/v1",
         "https://filecoin.drpc.org",
+        "https://filecoin.lava.build",
         "https://rpc.ankr.com/filecoin"
     ],
     "397": [
@@ -80,15 +134,25 @@
     ],
     "7700": [
         "https://canto-rpc.ansybl.io",
-        "https://canto.gravitychain.io/"
+        "https://canto.gravitychain.io"
     ],
     "8453": [
+        "https://1rpc.io/base",
+        "https://api.zan.top/base-mainnet",
+        "https://base-mainnet.gateway.tatum.io",
+        "https://base-mainnet.public.blastapi.io",
         "https://base-public.nodies.app",
         "https://base-rpc.publicnode.com",
         "https://base.drpc.org",
         "https://base.gateway.tenderly.co",
-        "https://developer-access-mainnet.base.org/",
-        "https://mainnet.base.org/"
+        "https://base.lava.build",
+        "https://base.meowrpc.com",
+        "https://base.public.blockpi.network/v1/rpc/public",
+        "https://base.rpc.subquery.network/public",
+        "https://developer-access-mainnet.base.org",
+        "https://gateway.tenderly.co/public/base",
+        "https://mainnet-preconf.base.org",
+        "https://mainnet.base.org"
     ],
     "10200": [
         "https://gnosis-chiado-rpc.publicnode.com",
@@ -97,32 +161,53 @@
         "https://rpc.chiadochain.net"
     ],
     "42161": [
+        "https://1rpc.io/arb",
+        "https://api.zan.top/arb-one",
         "https://arb1.arbitrum.io/rpc",
+        "https://arb1.lava.build",
         "https://arbitrum-one-public.nodies.app",
         "https://arbitrum-one-rpc.publicnode.com",
-        "https://arbitrum.drpc.org"
+        "https://arbitrum-one.public.blastapi.io",
+        "https://arbitrum.drpc.org",
+        "https://arbitrum.gateway.tenderly.co",
+        "https://arbitrum.meowrpc.com",
+        "https://arbitrum.public.blockpi.network/v1/rpc/public",
+        "https://arbitrum.rpc.subquery.network/public"
     ],
     "42220": [
         "https://1rpc.io/celo",
+        "https://celo-json-rpc.stakely.io",
         "https://celo.drpc.org",
-        "https://forno.celo.org"
+        "https://forno.celo.org",
+        "https://rpc.ankr.com/celo"
     ],
     "43114": [
+        "https://1rpc.io/avax/c",
         "https://api.avax.network/ext/bc/C/rpc",
+        "https://api.zan.top/avax-mainnet/ext/bc/C/rpc",
         "https://avalanche-c-chain-rpc.publicnode.com",
-        "https://avalanche.drpc.org"
+        "https://avalanche-mainnet.gateway.tenderly.co",
+        "https://avalanche-public.nodies.app/ext/bc/C/rpc",
+        "https://avalanche.api.onfinality.io/public/ext/bc/C/rpc",
+        "https://avalanche.drpc.org",
+        "https://spectrum-01.simplystaking.xyz/avalanche-mn-rpc/ext/bc/C/rpc"
     ],
     "80002": [
+        "https://api.zan.top/polygon-amoy",
         "https://polygon-amoy-bor-rpc.publicnode.com",
         "https://polygon-amoy-public.nodies.app",
+        "https://polygon-amoy.api.onfinality.io/public",
         "https://polygon-amoy.drpc.org",
+        "https://polygon-amoy.gateway.tenderly.co",
         "https://rpc-amoy.polygon.technology"
     ],
     "84532": [
         "https://base-sepolia-public.nodies.app",
         "https://base-sepolia-rpc.publicnode.com",
+        "https://base-sepolia.api.onfinality.io/public",
         "https://base-sepolia.drpc.org",
         "https://base-sepolia.gateway.tenderly.co",
+        "https://sepolia-preconf.base.org",
         "https://sepolia.base.org"
     ],
     "421614": [
@@ -139,13 +224,22 @@
         "https://sepolia-rpc.scroll.io"
     ],
     "534352": [
+        "https://1rpc.io/scroll",
         "https://rpc.scroll.io",
         "https://scroll-public.nodies.app",
         "https://scroll-rpc.publicnode.com",
+        "https://scroll.api.onfinality.io/public",
         "https://scroll.drpc.org"
     ],
     "11155111": [
+        "https://0xrpc.io/sep",
+        "https://1rpc.io/sepolia",
+        "https://api.zan.top/eth-sepolia",
+        "https://eth-sepolia.api.onfinality.io/public",
+        "https://ethereum-sepolia-public.nodies.app",
         "https://ethereum-sepolia-rpc.publicnode.com",
+        "https://ethereum-sepolia.rpc.subquery.network/public",
+        "https://gateway.tenderly.co/public/sepolia",
         "https://rpc.sepolia.ethpandaops.io",
         "https://sepolia.drpc.org",
         "https://sepolia.gateway.tenderly.co"
@@ -153,6 +247,8 @@
     "11155420": [
         "https://api.zan.top/opt-sepolia",
         "https://optimism-sepolia-public.nodies.app",
+        "https://optimism-sepolia.api.onfinality.io/public",
+        "https://optimism-sepolia.drpc.org",
         "https://optimism-sepolia.gateway.tenderly.co",
         "https://sepolia.optimism.io"
     ],

--- a/scripts/generate_endpoint_mapping.py
+++ b/scripts/generate_endpoint_mapping.py
@@ -1,8 +1,6 @@
 import asyncio
 import time
-from functools import wraps
 
-import click
 from aiohttp import ClientSession
 from typing import Dict, List, Tuple
 from urllib.parse import urlparse
@@ -322,17 +320,6 @@ async def collect_rpc_endpoint_mappings(chains: List[int]) -> Dict[str, List[str
     return rpc_endpoints_dict
 
 
-# We can use `asyncclick` instead but not looking to add more dependencies than we need.
-def async_coro(f):
-    @wraps(f)
-    def wrapper(*args, **kwargs):
-        return asyncio.run(f(*args, **kwargs))
-
-    return wrapper
-
-
-@click.command()
-@async_coro
 async def generate_endpoint_mapping():
     """
     Generate rpc endpoint mappings file for relevant chains for all TACo domains.
@@ -347,4 +334,5 @@ async def generate_endpoint_mapping():
     print("\n-- All done! --")
 
 
-asyncio.run(generate_endpoint_mapping())
+if __name__ == "__main__":
+    asyncio.run(generate_endpoint_mapping())

--- a/scripts/generate_endpoint_mapping.py
+++ b/scripts/generate_endpoint_mapping.py
@@ -115,14 +115,6 @@ CHAINID_NETWORK = "https://chainid.network/chains.json"
 IPFS_SUPPLEMENTAL_URL = "https://gateway.pinata.cloud/ipfs/bafkreidw44bgpzeafnw4a7sgwv3mt2hvisuufumnucbglkefl2joetkimq"
 
 
-class InvalidChainConfiguration(ValueError):
-    """
-    Raised when endpoint's chain id does not matched expected chain id.
-    """
-
-    pass
-
-
 def process_rpc_endpoints(endpoints: List[str]) -> List[str]:
     rpc_endpoints = set()
     for endpoint in endpoints:
@@ -243,9 +235,10 @@ async def _rpc_endpoint_health_check(
             session, endpoint, expected_chain_id
         )
         if not validated_chain_id:
-            raise InvalidChainConfiguration(
+            print(
                 f"[x!] chain={expected_chain_id}: [CONFIG ERROR] RPC endpoint {endpoint} configured for incorrect chain"
             )
+            return False, endpoint
 
         validated_block_time = await _validate_block_time(
             session, endpoint, max_drift_seconds
@@ -257,9 +250,6 @@ async def _rpc_endpoint_health_check(
             return False, endpoint
 
         return True, endpoint
-
-    except InvalidChainConfiguration as e:
-        raise e
     except Exception as e:
         print(
             f"[x] chain={expected_chain_id}: RPC endpoint {endpoint} failed health check: {e.__class__} - {e}"

--- a/scripts/generate_endpoint_mapping.py
+++ b/scripts/generate_endpoint_mapping.py
@@ -133,9 +133,21 @@ def process_rpc_endpoints(endpoints: List[str]) -> List[str]:
             # - https://mainnet.infura.io/v3/${ALCHEMY_API_KEY}
             continue
 
-        # only use https endpoints
         url_components = urlparse(endpoint)
+
+        # only use https endpoints
         if url_components.scheme != "https":
+            continue
+
+        # urls with API keys aren't likely to work long term
+        contains_api_key = False
+        segments = url_components.path.split("/")
+        for segment in segments:
+            # Segments that are 16+ chars are likely API keys/secrets
+            if len(segment) >= 16:
+                contains_api_key = True
+                break
+        if contains_api_key:
             continue
 
         rpc_endpoints.add(endpoint)

--- a/scripts/generate_endpoint_mapping.py
+++ b/scripts/generate_endpoint_mapping.py
@@ -315,7 +315,9 @@ async def collect_rpc_endpoint_mappings(chains: List[int]) -> Dict[str, List[str
             endpoints_for_chain.update(supp_endpoints)
 
             # 3. get endpoints from extra rpc urls source
-            extra_endpoints = EXTRA_KNOWN_RPC_ENDPOINTS.get(chain_id, [])
+            extra_endpoints = process_rpc_endpoints(
+                EXTRA_KNOWN_RPC_ENDPOINTS.get(chain_id, [])
+            )
             endpoints_for_chain.update(extra_endpoints)
 
             # 3. perform health check on rpc endpoints

--- a/scripts/generate_endpoint_mapping.py
+++ b/scripts/generate_endpoint_mapping.py
@@ -4,13 +4,12 @@ from functools import wraps
 
 import click
 from aiohttp import ClientSession
-from pathlib import Path
 from typing import Dict, List, Tuple
 from urllib.parse import urlparse
 
 from utils import get_file_for_domain, write_endpoint_mappings_to_file
 
-ALL_CHAINS = {
+ALL_CHAINS = [
     1,  # Ethereum Mainnet
     10,  # OP Mainnet
     42,  # LUKSO Mainnet
@@ -40,7 +39,7 @@ ALL_CHAINS = {
     11155111,  # Sepolia
     11155420,  # OP Sepolia Testnet
     1660990954,  # Status Sepolia Testnet
-}
+]
 
 #
 # Additional endpoints to augment chainid.network list:
@@ -114,14 +113,8 @@ EXTRA_KNOWN_RPC_ENDPOINTS = {
 
 DOMAINS = ["lynx", "tapir", "mainnet"]
 
-DOMAIN_CHAINS = {
-    "lynx": ALL_CHAINS,
-    "tapir": ALL_CHAINS,
-    "mainnet": ALL_CHAINS,
-}
-
 CHAINID_NETWORK = "https://chainid.network/chains.json"
-LYNX_JSON = Path(__file__).parent.parent / "lynx.json"
+IPFS_SUPPLEMENTAL_URL = "https://gateway.pinata.cloud/ipfs/bafkreidw44bgpzeafnw4a7sgwv3mt2hvisuufumnucbglkefl2joetkimq"
 
 
 class InvalidChainConfiguration(ValueError):
@@ -152,14 +145,14 @@ def process_rpc_endpoints(endpoints: List[str]) -> List[str]:
 
 
 async def _fetch_chain_id_network_public_rpc_endpoints(
-    session: ClientSession, domain_chains: List[int]
+    session: ClientSession, chains: List[int]
 ) -> Dict[int, List[str]]:
     async with session.get(CHAINID_NETWORK) as response:
         chain_id_network_result = await response.json()
         chain_id_endpoints_dict = {}
         for entry in chain_id_network_result:
             chain_id = entry["chainId"]
-            if chain_id in domain_chains:
+            if chain_id in chains:
                 chain_id_endpoints_dict[chain_id] = process_rpc_endpoints(
                     entry.get("rpc", [])
                 )
@@ -251,17 +244,41 @@ async def _rpc_endpoint_health_check(
         return False, endpoint
 
 
-async def collect_rpc_endpoint_mappings(domain) -> Dict[str, List[str]]:
+async def _fetch_supplemental_endpoints(chains: List[int]) -> Dict[int, List[str]]:
+    """
+    Fetch supplemental rpc endpoints from IPFS.
+    """
+    async with ClientSession() as session:
+        async with session.get(IPFS_SUPPLEMENTAL_URL) as response:
+            result = await response.json()
+            supplemental_endpoints = {}
+            for entry in result.values():
+                if "chainId" not in entry or "endpoints" not in entry:
+                    # skip entries that don't have chainId or endpoints keys (eg. 'metadata' entry)
+                    continue
+
+                chain_id = entry["chainId"]
+                if chain_id in chains:
+                    endpoints_for_chain = entry["endpoints"]
+                    if endpoints_for_chain:
+                        supplemental_endpoints[chain_id] = process_rpc_endpoints(
+                            endpoints_for_chain
+                        )
+
+            return supplemental_endpoints
+
+
+async def collect_rpc_endpoint_mappings(chains: List[int]) -> Dict[str, List[str]]:
     rpc_endpoints_dict = {}
 
-    domain_chains = DOMAIN_CHAINS[domain]
+    supplemental_endpoints = await _fetch_supplemental_endpoints(chains)
 
     # do this once
     async with ClientSession() as session:
         chain_id_network_rpc_endpoints = (
-            await _fetch_chain_id_network_public_rpc_endpoints(session, domain_chains)
+            await _fetch_chain_id_network_public_rpc_endpoints(session, chains)
         )
-        for chain_id in domain_chains:
+        for chain_id in chains:
             endpoints_for_chain = set()
 
             # 1. get endpoints from chain id source
@@ -270,7 +287,11 @@ async def collect_rpc_endpoint_mappings(domain) -> Dict[str, List[str]]:
             )
             endpoints_for_chain.update(chain_id_network_endpoints)
 
-            # 2. get endpoints from extra rpc urls source
+            # 2. add supplemental endpoints from ipfs source: https://docs.erpc.cloud/free#how-it-works
+            supp_endpoints = supplemental_endpoints.get(chain_id, [])
+            endpoints_for_chain.update(supp_endpoints)
+
+            # 3. get endpoints from extra rpc urls source
             extra_endpoints = EXTRA_KNOWN_RPC_ENDPOINTS.get(chain_id, [])
             endpoints_for_chain.update(extra_endpoints)
 
@@ -311,22 +332,13 @@ def async_coro(f):
 
 
 @click.command()
-@click.option(
-    "--domain",
-    "domain",
-    help="TACo Domain",
-    type=click.Choice(["lynx", "tapir", "mainnet"]),
-    required=False,
-)
 @async_coro
-async def generate_endpoint_mapping(domain):
+async def generate_endpoint_mapping():
     """
-    Generate rpc endpoint mappings file for chains associated with domain. If domain is not
-    specified, then mappings files are generated for all supported domains.
+    Generate rpc endpoint mappings file for relevant chains for all TACo domains.
     """
-    domains = [domain] if domain else DOMAINS
-    for domain in domains:
-        endpoint_mappings = await collect_rpc_endpoint_mappings(domain)
+    endpoint_mappings = await collect_rpc_endpoint_mappings(ALL_CHAINS)
+    for domain in DOMAINS:
         domain_json_file = get_file_for_domain(domain)
         write_endpoint_mappings_to_file(
             json_file=domain_json_file, endpoint_mappings=endpoint_mappings

--- a/scripts/generate_endpoint_mapping.py
+++ b/scripts/generate_endpoint_mapping.py
@@ -140,15 +140,28 @@ def process_rpc_endpoints(endpoints: List[str]) -> List[str]:
             continue
 
         # urls with API keys aren't likely to work long term
-        contains_api_key = False
+        # 1. don't use URLs with query strings - these are likely to contain API keys
+        if url_components.query:
+            print(
+                f"[x] Skipping endpoint with query string (potential API key): {endpoint}"
+            )
+            continue
+
+        # 2. check path
+        path_potentially_contains_api_key = False
         segments = url_components.path.split("/")
         for segment in segments:
-            # Segments that are 16+ chars are likely API keys/secrets
-            if len(segment) >= 16:
-                contains_api_key = True
+            # segments that are 24+ chars are likely API keys/secrets
+            # really they seem to be >= 32 chars but using 24 to be more conservative
+            if len(segment) >= 24:
+                path_potentially_contains_api_key = True
                 break
-        if contains_api_key:
+        if path_potentially_contains_api_key:
+            print(f"[x] Skipping endpoint with potential API key in path: {endpoint}")
             continue
+
+        # strip trailing slash if it exists for consistency
+        endpoint = endpoint.rstrip("/")
 
         rpc_endpoints.add(endpoint)
     return list(rpc_endpoints)

--- a/tapir.json
+++ b/tapir.json
@@ -1,29 +1,62 @@
 {
     "1": [
+        "https://0xrpc.io/eth",
+        "https://1rpc.io/eth",
+        "https://api.zan.top/eth-mainnet",
+        "https://core.gashawk.io/rpc",
+        "https://eth-mainnet.public.blastapi.io",
+        "https://eth.api.onfinality.io/public",
+        "https://eth.blockrazor.xyz",
         "https://eth.drpc.org",
+        "https://eth.llamarpc.com",
+        "https://eth.meowrpc.com",
+        "https://eth.merkle.io",
+        "https://eth.rpc.blxrbdn.com",
+        "https://eth1.lava.build",
         "https://ethereum-public.nodies.app",
         "https://ethereum-rpc.publicnode.com",
+        "https://ethereum.public.blockpi.network/v1/rpc/public",
+        "https://ethereum.rpc.subquery.network/public",
+        "https://gateway.tenderly.co/public/mainnet",
         "https://mainnet.gateway.tenderly.co",
+        "https://rpc.eth.gateway.fm",
         "https://rpc.flashbots.net",
         "https://rpc.flashbots.net/fast",
         "https://rpc.mevblocker.io",
         "https://rpc.mevblocker.io/fast",
         "https://rpc.mevblocker.io/fullprivacy",
-        "https://rpc.mevblocker.io/noreverts"
+        "https://rpc.mevblocker.io/noreverts",
+        "https://singapore.rpc.blxrbdn.com",
+        "https://uk.rpc.blxrbdn.com",
+        "https://virginia.rpc.blxrbdn.com"
     ],
     "10": [
+        "https://1rpc.io/op",
+        "https://api.zan.top/opt-mainnet",
+        "https://gateway.tenderly.co/public/optimism",
         "https://mainnet.optimism.io",
         "https://optimism-public.nodies.app",
         "https://optimism-rpc.publicnode.com",
+        "https://optimism.api.onfinality.io/public",
         "https://optimism.drpc.org",
-        "https://optimism.gateway.tenderly.co"
+        "https://optimism.gateway.tenderly.co",
+        "https://optimism.public.blockpi.network/v1/rpc/public",
+        "https://optimism.rpc.subquery.network/public"
     ],
     "42": [
         "https://42.rpc.thirdweb.com",
         "https://rpc.mainnet.lukso.network"
     ],
     "56": [
+        "https://0.48.club",
+        "https://1rpc.io/bnb",
+        "https://56.rpc.thirdweb.com",
+        "https://api.zan.top/bsc-mainnet",
         "https://binance-smart-chain-public.nodies.app",
+        "https://binance.nodereal.io",
+        "https://bnb.api.onfinality.io/public",
+        "https://bnb.rpc.subquery.network/public",
+        "https://bsc-dataseed.bnbchain.org",
         "https://bsc-dataseed1.bnbchain.org",
         "https://bsc-dataseed1.defibit.io",
         "https://bsc-dataseed1.ninicoin.io",
@@ -36,10 +69,17 @@
         "https://bsc-dataseed4.bnbchain.org",
         "https://bsc-dataseed4.defibit.io",
         "https://bsc-dataseed4.ninicoin.io",
+        "https://bsc-mainnet.public.blastapi.io",
         "https://bsc-rpc.publicnode.com",
-        "https://bsc.drpc.org"
+        "https://bsc.blockrazor.xyz",
+        "https://bsc.drpc.org",
+        "https://bsc.meowrpc.com",
+        "https://bsc.rpc.blxrbdn.com",
+        "https://rpc-bsc.48.club"
     ],
     "97": [
+        "https://api.zan.top/bsc-testnet",
+        "https://bnb-testnet.api.onfinality.io/public",
         "https://bsc-testnet-rpc.publicnode.com",
         "https://bsc-testnet.drpc.org",
         "https://data-seed-prebsc-1-s1.bnbchain.org:8545",
@@ -50,27 +90,40 @@
         "https://data-seed-prebsc-2-s3.bnbchain.org:8545"
     ],
     "100": [
+        "https://1rpc.io/gnosis",
         "https://gnosis-public.nodies.app",
         "https://gnosis-rpc.publicnode.com",
         "https://gnosis.drpc.org",
         "https://gnosis.oat.farm",
+        "https://rpc.ap-southeast-1.gateway.fm/v4/gnosis/non-archival/mainnet",
         "https://rpc.gnosis.gateway.fm",
         "https://rpc.gnosischain.com"
     ],
     "137": [
+        "https://1rpc.io/matic",
+        "https://api.zan.top/polygon-mainnet",
+        "https://gateway.tenderly.co/public/polygon",
         "https://polygon-bor-rpc.publicnode.com",
+        "https://polygon-mainnet.gateway.tatum.io",
         "https://polygon-public.nodies.app",
+        "https://polygon.api.onfinality.io/public",
         "https://polygon.drpc.org",
         "https://polygon.gateway.tenderly.co",
+        "https://polygon.lava.build",
+        "https://polygon.rpc.subquery.network/public",
         "https://rpc-mainnet.matic.quiknode.pro"
     ],
     "300": [
+        "https://rpc.ankr.com/zksync_era_sepolia",
         "https://sepolia.era.zksync.dev",
         "https://zksync-sepolia.drpc.org"
     ],
     "314": [
-        "https://api.node.glif.io/",
+        "https://api.chain.love/rpc/v1",
+        "https://api.node.glif.io",
+        "https://api.node.glif.io/rpc/v1",
         "https://filecoin.drpc.org",
+        "https://filecoin.lava.build",
         "https://rpc.ankr.com/filecoin"
     ],
     "397": [
@@ -81,15 +134,25 @@
     ],
     "7700": [
         "https://canto-rpc.ansybl.io",
-        "https://canto.gravitychain.io/"
+        "https://canto.gravitychain.io"
     ],
     "8453": [
+        "https://1rpc.io/base",
+        "https://api.zan.top/base-mainnet",
+        "https://base-mainnet.gateway.tatum.io",
+        "https://base-mainnet.public.blastapi.io",
         "https://base-public.nodies.app",
         "https://base-rpc.publicnode.com",
         "https://base.drpc.org",
         "https://base.gateway.tenderly.co",
-        "https://developer-access-mainnet.base.org/",
-        "https://mainnet.base.org/"
+        "https://base.lava.build",
+        "https://base.meowrpc.com",
+        "https://base.public.blockpi.network/v1/rpc/public",
+        "https://base.rpc.subquery.network/public",
+        "https://developer-access-mainnet.base.org",
+        "https://gateway.tenderly.co/public/base",
+        "https://mainnet-preconf.base.org",
+        "https://mainnet.base.org"
     ],
     "10200": [
         "https://gnosis-chiado-rpc.publicnode.com",
@@ -98,32 +161,53 @@
         "https://rpc.chiadochain.net"
     ],
     "42161": [
+        "https://1rpc.io/arb",
+        "https://api.zan.top/arb-one",
         "https://arb1.arbitrum.io/rpc",
+        "https://arb1.lava.build",
         "https://arbitrum-one-public.nodies.app",
         "https://arbitrum-one-rpc.publicnode.com",
-        "https://arbitrum.drpc.org"
+        "https://arbitrum-one.public.blastapi.io",
+        "https://arbitrum.drpc.org",
+        "https://arbitrum.gateway.tenderly.co",
+        "https://arbitrum.meowrpc.com",
+        "https://arbitrum.public.blockpi.network/v1/rpc/public",
+        "https://arbitrum.rpc.subquery.network/public"
     ],
     "42220": [
         "https://1rpc.io/celo",
+        "https://celo-json-rpc.stakely.io",
         "https://celo.drpc.org",
-        "https://forno.celo.org"
+        "https://forno.celo.org",
+        "https://rpc.ankr.com/celo"
     ],
     "43114": [
+        "https://1rpc.io/avax/c",
         "https://api.avax.network/ext/bc/C/rpc",
+        "https://api.zan.top/avax-mainnet/ext/bc/C/rpc",
         "https://avalanche-c-chain-rpc.publicnode.com",
-        "https://avalanche.drpc.org"
+        "https://avalanche-mainnet.gateway.tenderly.co",
+        "https://avalanche-public.nodies.app/ext/bc/C/rpc",
+        "https://avalanche.api.onfinality.io/public/ext/bc/C/rpc",
+        "https://avalanche.drpc.org",
+        "https://spectrum-01.simplystaking.xyz/avalanche-mn-rpc/ext/bc/C/rpc"
     ],
     "80002": [
+        "https://api.zan.top/polygon-amoy",
         "https://polygon-amoy-bor-rpc.publicnode.com",
         "https://polygon-amoy-public.nodies.app",
+        "https://polygon-amoy.api.onfinality.io/public",
         "https://polygon-amoy.drpc.org",
+        "https://polygon-amoy.gateway.tenderly.co",
         "https://rpc-amoy.polygon.technology"
     ],
     "84532": [
         "https://base-sepolia-public.nodies.app",
         "https://base-sepolia-rpc.publicnode.com",
+        "https://base-sepolia.api.onfinality.io/public",
         "https://base-sepolia.drpc.org",
         "https://base-sepolia.gateway.tenderly.co",
+        "https://sepolia-preconf.base.org",
         "https://sepolia.base.org"
     ],
     "421614": [
@@ -140,13 +224,22 @@
         "https://sepolia-rpc.scroll.io"
     ],
     "534352": [
+        "https://1rpc.io/scroll",
         "https://rpc.scroll.io",
         "https://scroll-public.nodies.app",
         "https://scroll-rpc.publicnode.com",
+        "https://scroll.api.onfinality.io/public",
         "https://scroll.drpc.org"
     ],
     "11155111": [
+        "https://0xrpc.io/sep",
+        "https://1rpc.io/sepolia",
+        "https://api.zan.top/eth-sepolia",
+        "https://eth-sepolia.api.onfinality.io/public",
+        "https://ethereum-sepolia-public.nodies.app",
         "https://ethereum-sepolia-rpc.publicnode.com",
+        "https://ethereum-sepolia.rpc.subquery.network/public",
+        "https://gateway.tenderly.co/public/sepolia",
         "https://rpc.sepolia.ethpandaops.io",
         "https://sepolia.drpc.org",
         "https://sepolia.gateway.tenderly.co"
@@ -154,6 +247,7 @@
     "11155420": [
         "https://api.zan.top/opt-sepolia",
         "https://optimism-sepolia-public.nodies.app",
+        "https://optimism-sepolia.api.onfinality.io/public",
         "https://optimism-sepolia.drpc.org",
         "https://optimism-sepolia.gateway.tenderly.co",
         "https://sepolia.optimism.io"


### PR DESCRIPTION
**Required reviews:** 
- [x] 1
- [ ] 2
- [ ] 3


**What this does:**
- Obtain supplemental endpoints from IPFS; this IPFS file is used by [erpc](https://docs.erpc.cloud/free) (IPFS link https://evm-public-endpoints.erpc.cloud/). This adds a number of new public RPC URLs. Note: our health checks as part of the script are pivotal because some entries are incorrect eg.
```
[x] chain=1: RPC endpoint https://0xrpc.io/gno failed health check: <class 'aiohttp.client_exceptions.ContentTypeError'> - 404, message='Attempt to decode JSON with unexpected mimetype: text/html', url='https://0xrpc.io/gno'
[x!] chain=1: [CONFIG ERROR] RPC endpoint https://rpc.etcinscribe.com configured for incorrect chain
[x!] chain=1: [CONFIG ERROR] RPC endpoint https://dataseed3.idn-rpc.com configured for incorrect chain
[x!] chain=1: [CONFIG ERROR] RPC endpoint https://api.zan.top/polygon-mainnet configured for incorrect chain
[x!] chain=1: [CONFIG ERROR] RPC endpoint https://api.zan.top/ftm-mainnet configured for incorrect chain
``` 
- Since all domains now use the same chain list, remove `--domain` parameter and simplify script to create the mapping once and then write to all 3 domain files. Instead of performing the generation per domain which is inefficient
- Remove any URLs that seemingly include API keys: any URL with a query OR path entry with length >= 24 (note that https://github.com/nucypher/nucypher/pull/3702 used >=16). The reason being that there were some cases of non-API key URLs with path segments ~16 chars eg. 
  - `https://spectrum-01.simplystaking.xyz/avalanche-mn-rpc/ext/bc/C/rpc`
  - `https://rpc.ankr.com/zksync_era_sepolia`